### PR TITLE
Both Timecode and Timestamp can be used by muxers

### DIFF
--- a/EBML.js
+++ b/EBML.js
@@ -560,7 +560,7 @@ var EBMLReader = /** @class */ (function (_super) {
             this.emit("cluster_ptr", elm.tagStart);
             this.lastClusterPosition = elm.tagStart;
         }
-        else if (elm.type === "u" && elm.name === "Timecode") {
+        else if (elm.type === "u" && (elm.name === "Timecode" || elm.name === "Timestamp")) {
             this.lastClusterTimecode = elm.value;
         }
         else if (elm.type === "u" && elm.name === "TimecodeScale") {


### PR DESCRIPTION
Both Timecode and Timestamp can be used by muxers.
Fixes https://github.com/davedoesdev/webm-muxer.js/issues/26